### PR TITLE
show(): Fixed documentation

### DIFF
--- a/entries/show.xml
+++ b/entries/show.xml
@@ -32,10 +32,9 @@
     <pre><code>
 $( ".target" ).show();
     </code></pre>
-    <p>The matched elements will be revealed immediately, with no animation. This is roughly equivalent to calling <code>.css( "display", "block")</code>, except that the <code>display</code> property is restored to whatever it was initially. If an element has a <code>display</code> value of <code>inline</code>, then is hidden and shown, it will once again be displayed <code>inline</code>.</p>
-    <p><strong>Note: </strong> If using !important in your styles, such as
-    <code>display: none !important</code>,
-    it is necessary to override the style using <code>.css( "display", "block !important")</code> should you wish for <code>.show()</code> to function correctly.</p>
+    <p>The matched elements will be revealed immediately, with no animation. This is roughly equivalent to calling <code>.css("display", "block")</code>, except that the <code>display</code> property is restored to whatever it was initially. If an element has a <code>display</code> value of <code>inline</code>, then is hidden and shown, it will once again be displayed <code>inline</code>.</p>
+    <p><strong>Note: </strong> If using !important in your styles, such as <code>display: none !important</code>, <code>.show()</code> will not override <code>!important</code>.
+    It is recommended to use different classes with <code>.addClass()</code>, <code>.removeClass()</code> or <code>.toggleClass()</code>. Another approach can be the use of <code>.attr("style","display:block !important")</code>, being careful not to overwrite the style attribute of the element.</p>
     <p>When a duration, a plain object, or a "complete" function is provided, <code>.show()</code> becomes an animation method. The <code>.show()</code> method animates the width, height, and opacity of the matched elements simultaneously.</p>
     <p>Durations are given in milliseconds; higher values indicate slower animations, not faster ones. The strings <code>'fast'</code> and <code>'slow'</code> can be supplied to indicate durations of <code>200</code> and <code>600</code> milliseconds, respectively.</p>
     <p>As of jQuery 1.4.3, an optional string naming an easing function may be used. Easing functions specify the speed at which the animation progresses at different points within the animation. The only easing implementations in the jQuery library are the default, called <code>swing</code>, and one that progresses at a constant pace, called <code>linear</code>. More easing functions are available with the use of plug-ins, most notably the <a href="http://jqueryui.com">jQuery UI suite</a>.</p>


### PR DESCRIPTION
There was a contradiction between show() and css() documentation about !important behaviour